### PR TITLE
Update lecture-18.tex

### DIFF
--- a/WS2016/Vorlesungen/lecture-18.tex
+++ b/WS2016/Vorlesungen/lecture-18.tex
@@ -176,7 +176,7 @@ den folgenden Bestandteilen:
 \item $\delta$: \redalert{Übergangsfunktion}, eine partielle Funktion\\[1ex]
 \narrowcentering{$Q\times\Gamma \to Q\times\Gamma\times\{L,R,N\}$}
 % , wobei $2^Q$ die Potenzmenge von $Q$ ist
-\item $q_0$: \redalert{Startzustand} $q_0\subseteq Q$
+\item $q_0$: \redalert{Startzustand} $q_0\in Q$
 \item $F$: Menge von akzeptierenden \redalert{Endzuständen} $F\subseteq Q$
 \end{itemize}
 }


### PR DESCRIPTION
q0 müsste Element von Q sein, da eine TM nur einen Startzustand hat (deterministisch).
Alternativ, falls q0 eine Menge von Startzuständen ist, sollte q0 in Q0 umbenannt werden, um konsistent mit den restlichen Folien zu bleiben.