### PR TITLE
fix: improve build.sh portability

### DIFF
--- a/Vorlesungen/build.sh
+++ b/Vorlesungen/build.sh
@@ -10,13 +10,13 @@ tmpfilename="tmplecturefile" # don't have any files called like this!
 printfilename=$fileprefix$1-print.pdf
 overlayfilename=$fileprefix$1-overlay.pdf
 
-echo "\documentclass[aspectratio=1610,onlymath,handout]{beamer}\n" > $tmpfilename.tex
+printf "\documentclass[aspectratio=1610,onlymath,handout]{beamer}\n\n" > $tmpfilename.tex
 tail -n +3 lecture-$1.tex >> $tmpfilename.tex
 pdflatex $tmpfilename.tex
 pdflatex $tmpfilename.tex
 pdfnup --nup 2x2 --outfile $printfilename $tmpfilename.pdf
 
-echo "\documentclass[aspectratio=1610,onlymath]{beamer}\n" > $tmpfilename.tex
+printf "\documentclass[aspectratio=1610,onlymath]{beamer}\n\n" > $tmpfilename.tex
 tail -n +3 lecture-$1.tex >> $tmpfilename.tex
 pdflatex $tmpfilename.tex
 pdflatex $tmpfilename.tex
@@ -24,4 +24,4 @@ mv $tmpfilename.pdf $overlayfilename
 
 rm $tmpfilename.*
 
-echo "\n\n*** Finished creating files '$overlayfilename' and '$printfilename' ***\n"
+printf "\n\n*** Finished creating files '$overlayfilename' and '$printfilename' ***\n\n"


### PR DESCRIPTION
`echo` does not support escape sequences such as "\n" on all systems (it
fails on ArchLinux for example). Switching to `printf` solves this.