### PR TITLE
replaced pdfnup with the pdfjam script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PDFs erstellen
 
 Die Quellen können mit ```pdflatex``` in PDFs umgewandelt werden. Das Script
 [build.sh](https://github.com/knowsys/FormaleSysteme/blob/master/Vorlesungen/build.sh)
-erzeugt außerdem eine Druckversion mit vier Folien pro Seite (benötigt ```pdfnup```).
+erzeugt außerdem eine Druckversion mit vier Folien pro Seite (benötigt ```pdfjam```).
 
 Die fertigen PDFs aus dem Winter 2017/2018 sind online zu finden unter https://iccl.inf.tu-dresden.de/web/FS2017.
 Für das Wintersemester 2020/2021 werden die Folien unter https://iccl.inf.tu-dresden.de/web/FS2020 bereitgestellt.

--- a/Vorlesungen/build.sh
+++ b/Vorlesungen/build.sh
@@ -14,7 +14,7 @@ printf "\\documentclass[aspectratio=1610,onlymath,handout]{beamer}\n\n" > $tmpfi
 tail -n +3 lecture-$1.tex >> $tmpfilename.tex
 pdflatex $tmpfilename.tex
 pdflatex $tmpfilename.tex
-pdfnup --nup 2x2 --outfile $printfilename $tmpfilename.pdf
+pdfjam --nup 2x2 --outfile $printfilename $tmpfilename.pdf
 
 printf "\\documentclass[aspectratio=1610,onlymath]{beamer}\n\n" > $tmpfilename.tex
 tail -n +3 lecture-$1.tex >> $tmpfilename.tex


### PR DESCRIPTION
Verwenden des ```pdfjam``` script anstatt von ```pdfnup```. Der Autor von pdfjam hat einige scripte, unter anderem pdfnup, aus dem Repository entfernt.[0] Damit ist dieses Tool nicht mehr in den texlive enthalten. Pdfjam kann allerdings stattdessen verwendet werden.

[0] https://github.com/rrthomas/pdfjam/blob/master/README.md#-wrapper-scripts-no-longer-included-here