### PR TITLE
Fixed Typo

### DIFF
--- a/Vorlesungen/lecture-20.tex
+++ b/Vorlesungen/lecture-20.tex
@@ -366,7 +366,7 @@ Welches Berechnungsmodell entspricht den Typ-1-Sprachen?
 
 \emph{Lösung:} Beschränkung des Arbeitsspeichers einer TM:\medskip
 
-\defbox{Ein \redalert{linear beschränkte Turingmaschine} (\alert{linear-bounded automaton}, \alert{LBA}) ist eine nichtdeterministische Turingmaschine, die den Lese-/Schreibkopf nicht über das letzte Eingabezeichen hinaus
+\defbox{Eine \redalert{linear beschränkte Turingmaschine} (\alert{linear-bounded automaton}, \alert{LBA}) ist eine nichtdeterministische Turingmaschine, die den Lese-/Schreibkopf nicht über das letzte Eingabezeichen hinaus
 bewegen kann. Versucht sie das, so bleibt der Kopf stattdessen an der letzten Bandstelle stehen.}\medskip
 
 Ein LBA kann also nur die (lineare) Menge an Speicher nutzen, die durch die Eingabe belegt wird


### PR DESCRIPTION
Bezogen auf LBA wäre "Ein" korrekt. 
Hier würde ich es eher auf "linear beschränkte Turingmaschine" beziehen, weswegen es "Eine" heißen müsste.