### PR TITLE
Fix: Off by one error bei der Definition von einem Lauf eines NFA

### DIFF
--- a/Vorlesungen/lecture-04.tex
+++ b/Vorlesungen/lecture-04.tex
@@ -247,7 +247,7 @@ ist eine Folge von Zuständen $q_0\ldots q_m$, so dass gilt:
 \begin{itemize}
 \item $q_0\in Q_0$
 \item $q_{i+1}\in \delta(q_i,\sigma_{i+1})$ für alle $0\leq i<m$ 
-\item (1) $m=|w|=n$ oder (2) $m<n$ und $\delta(q_m,\sigma_m)=\emptyset$
+\item (1) $m=|w|=n$ oder (2) $m<n$ und $\delta(q_m,\sigma_{m+1})=\emptyset$
 \end{itemize}
 Ein Lauf heißt \redalert{akzeptierend}, falls $m=n$ und $q_n\in F$.\\ Andernfalls
 heißt der Lauf \redalert{verwerfend}.


### PR DESCRIPTION
Kann es sein, dass sich in hier in der 4. VL ein Fehler eingeschlichen hat? Meiner Meinung nach müsste das statt σ_m σ_m+1 sein, weil das Wort bei σ1 startet.
Wenn man zum Beispiel ein Wort w=σ1 gegeben hat, aber δ(q0, σ1) = ∅, dann hält es bei m=0 < n=1. σ0 existiert nicht.