### PR TITLE
Add 'Minecraft' to unexpected topics list

### DIFF
--- a/Vorlesungen/lecture-24.tex
+++ b/Vorlesungen/lecture-24.tex
@@ -96,7 +96,7 @@ einseitig/zweiseitig unendlich, \ghost{\ldots)}\vspace{-1.1ex}
 Scratch, ALGOL, Swift, Kotlin, Scheme, Objective-C, TeX, Logo, ASP, APL, Visual Basic .NET, awk, Smalltalk, Scala, Brainfuck,
 \ldots$^*$)}\vspace{-1.1ex}
 \item theoretische \alert{Kalküle} (Prädikatenlogik erster Stufe, $\lambda$-Kalkül, allgemeine rekursive Funktionen, \ldots)\vspace{-1.1ex}
-\item manch \alert{Unerwartetes} (C++-Templates, SQL, Java Generics, TypeScript Types, Magic: The Gathering, Microsoft Powerpoint, \ldots)
+\item manch \alert{Unerwartetes} (C++-Templates, SQL, Java Generics, TypeScript Types, Magic: The Gathering, Microsoft Powerpoint, Minecraft, \ldots)
 \end{itemize}}
 \end{itemize}
 \ghost{\hspace{13.8cm}\rotatebox{90}{\tiny \hspace{5mm}$^*$ \alert{\href{https://w.wiki/HZNF}{populäre Programmiersprachen (geordnet nach Zahl internationaler Wikipedia-Artikel)}}}}


### PR DESCRIPTION
Minecraft ist turingmächtig, weil man mit Redstone alle essenziellen Logikgatter (wie AND, OR, NOT) nachbauen kann. Diese ermöglichen die Konstruktion eines universellen Computers innerhalb des Spiels, der theoretisch jede berechenbare mathematische Aufgabe lösen kann – begrenzt nur durch den verfügbaren Platz und die Rechenleistung der Hardware